### PR TITLE
Add Toggle To Instance UserData Field

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -6,12 +6,12 @@ Parameters:
   HostFamily:
     Type: String
     Description: Host type to provision, e.g. mac1 for mac1.metal.
-    Default: "mac1"
+    Default: "mac2"
 
   InstanceType:
     Type: String
     Description: Instance type to provision, e.g. mac1.metal.
-    Default: "mac1.metal"
+    Default: "mac2.metal"
 
   ImageId:
     Type: AWS::EC2::Image::Id
@@ -48,14 +48,62 @@ Parameters:
     Type: String
     NoEcho: true
     Description: "Buildkite Agent token from https://buildkite.com/organizations/-/agents"
+    Default: ""
 
   BuildkiteAgentQueue:
+    Description: Queue name that agents will use, targeted in pipeline steps using "queue={value}"
     Type: String
-    Description: Buildkite Queue to execute work for.
+    Default: default
+    MinLength: 1
+
+  KeyName:
+    Description: Optional - SSH keypair used to access the buildkite instances via ec2_user, setting this will enable SSH ingress
+    Type: String
+    Default: ""
+
+  EnableCostAllocationTags:
+    Type: String
+    Description: Enables AWS Cost Allocation tags for all resources in the stack. See https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "false"
+
+  CostAllocationTagName:
+    Type: String
+    Description: The name of the Cost Allocation Tag used for billing purposes
+    Default: "CreatedBy"
+
+  CostAllocationTagValue:
+    Type: String
+    Description: The value of the Cost Allocation Tag used for billing purposes
+    Default: "buildkite-elastic-ci-stack-for-aws"
+
+  InstanceName:
+    Type: String
+    Description: Optional - Customise the EC2 instance Name tag
+    Default: "buildkite-agent"
+
+  EnableInstanceUserData:
+    Type: String
+    Description: Optional - Disables the EC2 instance UserData
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "true"
 
 Conditions:
   IamInstanceProfileProvided:
     !Not [ !Equals [ "", !Ref IamInstanceProfile ] ]
+
+  HasKeyName:
+    !Not [ !Equals [ !Ref KeyName, "" ] ]
+
+  UseCostAllocationTags:
+    !Equals [ !Ref EnableCostAllocationTags, "true" ]
+
+  UseInstanceUserData:
+    !Equals [ !Ref EnableInstanceUserData, "true" ]
 
 Outputs:
   ResourceGroupId:
@@ -89,12 +137,14 @@ Resources:
             - Name: deletion-protection
               Values:
                 - UNLESS_EMPTY
+
   LaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Properties:
       LaunchTemplateData:
         ImageId: !Ref ImageId
         InstanceType: !Ref InstanceType
+        KeyName: !If [ "HasKeyName", !Ref KeyName, !Ref 'AWS::NoValue' ]
         Placement:
           HostResourceGroupArn: !GetAtt DedicatedHostGroup.Arn
         BlockDeviceMappings:
@@ -105,23 +155,41 @@ Resources:
         SecurityGroupIds: !Ref SecurityGroupIds
         IamInstanceProfile:
           Arn: !If [ IamInstanceProfileProvided, !Ref IamInstanceProfile, !Ref AWS::NoValue ] 
+        TagSpecifications:
+            - ResourceType: instance
+              Tags:
+                - Key: Role
+                  Value: buildkite-agent
+                - Key: Name
+                  Value: !Ref InstanceName
+                - Key: BuildkiteAgentQueue
+                  Value: !Ref BuildkiteAgentQueue
+                - !If
+                  - UseCostAllocationTags
+                  - Key: !Ref CostAllocationTagName
+                    Value: !Ref CostAllocationTagValue
+                  - !Ref "AWS::NoValue"
         UserData:
           Fn::Base64:
-            !Sub
-              |
-              #!/bin/bash
-              PDISK=$(diskutil list physical external | head -n1 | cut -d" " -f1)
-              APFSCONT=$(diskutil list physical external | grep "Apple_APFS" | tr -s " " | cut -d" " -f8)
-              yes | diskutil repairDisk $PDISK
-              diskutil apfs resizeContainer $APFSCONT 0
-              systemsetup -setcomputersleep never
-              user=ec2-user
-              su - "${!user}" -c 'brew install buildkite/buildkite/buildkite-agent'
-              config="$(brew --prefix)"/etc/buildkite-agent/buildkite-agent.cfg
-              sed -i '' "s/xxx/${BuildkiteAgentToken}/g" "${!config}"
-              echo "tags=\"queue=${BuildkiteAgentQueue},buildkite-mac-stack=%v\"" >> "${!config}"
-              echo "tags-from-ec2=true" >> "${!config}"
-              su - "${!user}" -c 'brew services start buildkite/buildkite/buildkite-agent'
+            !If
+              - UseInstanceUserData
+              - !Sub |
+                  #!/bin/bash
+                  PDISK=$(diskutil list physical external | head -n1 | cut -d" " -f1)
+                  APFSCONT=$(diskutil list physical external | grep "Apple_APFS" | tr -s " " | cut -d" " -f8)
+                  yes | diskutil repairDisk $PDISK
+                  diskutil apfs resizeContainer $APFSCONT 0
+                  systemsetup -setcomputersleep never
+                  user=ec2-user
+                  su - "${!user}" -c 'brew install buildkite/buildkite/buildkite-agent'
+                  config="$(brew --prefix)"/etc/buildkite-agent/buildkite-agent.cfg
+                  sed -i '' "s/xxx/${BuildkiteAgentToken}/g" "${!config}"
+                  echo "tags=\"queue=${BuildkiteAgentQueue},buildkite-mac-stack=%v\"" >> "${!config}"
+                  echo "tags-from-ec2=true" >> "${!config}"
+                  su - "${!user}" -c 'brew services start buildkite/buildkite/buildkite-agent'
+              - |
+                #!/bin/bash
+                echo "UserData was disabled"
 
   AutoScaleGroup:
     Type: AWS::AutoScaling::AutoScalingGroup

--- a/template.yml
+++ b/template.yml
@@ -84,15 +84,26 @@ Parameters:
     Description: Optional - Customise the EC2 instance Name tag
     Default: "buildkite-agent"
 
+  EnableInstanceUserData:
+    Type: String
+    Description: Optional - Enables the bootstrap commands for EC2 instances in the UserData field of the launch template
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "true"
+
 Conditions:
   IamInstanceProfileProvided:
     !Not [ !Equals [ "", !Ref IamInstanceProfile ] ]
 
   HasKeyName:
-      !Not [ !Equals [ !Ref KeyName, "" ] ]
+    !Not [ !Equals [ !Ref KeyName, "" ] ]
 
   UseCostAllocationTags:
-      !Equals [ !Ref EnableCostAllocationTags, "true" ]
+    !Equals [ !Ref EnableCostAllocationTags, "true" ]
+
+  UseInstanceUserData:
+    !Equals [ !Ref EnableInstanceUserData, "true" ]
 
 Outputs:
   ResourceGroupId:


### PR DESCRIPTION
# Description

This PR adds a new flag to toggle the `UserData` field of the instance's `LaunchTemplate`.

The commands on the field sometimes break or are not necessary in some environments. I personally prefer to add them directly to the AMI.

I tried a few alternatives, as described below, but at the end a toggle is the solution that made more sense from a technical and user experience perspective.

## Alternative Approaches to the Solution

### Provide Your Own LaunchTemplate object
I thought about this alternative solution, however the LaunchTemplate is the core object so if you prefer not using the default one it is much better to just create your own template based on Buildkite's one, since you will have to basically bring all of the parameters plus the `DedicatedHost` as the LaunchTemplate depends on them.

### Add custom commands
Instead of a toggle I also thought about enabling the user to provide their own commands. The problem here is that this field uses a lot of interpolation which might not be done. Also, providing multiline values as a parameter in the command line is not a good experience either.

## FAQ

### Why set the default value of the buildkite token to an empty string?
This value is only used when you have the `UserData` field enabled as the commands there sets up the agent's configuration. If you disabled the `UserData` then you do not need to provide the configuration as, for example, you added it directly to the AMI or you do it in another way.

### Do the changes respect current users?
Yes, none of the changes I propose will break current users.