### PR TITLE
Set $PATH to include Homebrew

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -181,7 +181,7 @@ Resources:
                   diskutil apfs resizeContainer $APFSCONT 0
                   systemsetup -setcomputersleep never
                   sudo -u ec2-user -i <<'EOF'
-                  export PATH="/opt/homebrew/bin:$PATH"
+                  [ -x /opt/homebrew/bin/brew ] && eval "$(/opt/homebrew/bin/brew shellenv)"
                   brew install buildkite/buildkite/buildkite-agent
                   config="$(brew --prefix)"/etc/buildkite-agent/buildkite-agent.cfg
                   sed -i '' "s/xxx/${BuildkiteAgentToken}/g" "${!config}"

--- a/template.yml
+++ b/template.yml
@@ -154,7 +154,7 @@ Resources:
               VolumeType: gp3
         SecurityGroupIds: !Ref SecurityGroupIds
         IamInstanceProfile:
-          Arn: !If [ IamInstanceProfileProvided, !Ref IamInstanceProfile, !Ref AWS::NoValue ] 
+          Arn: !If [ IamInstanceProfileProvided, !Ref IamInstanceProfile, !Ref AWS::NoValue ]
         TagSpecifications:
             - ResourceType: instance
               Tags:
@@ -180,13 +180,15 @@ Resources:
                   yes | diskutil repairDisk $PDISK
                   diskutil apfs resizeContainer $APFSCONT 0
                   systemsetup -setcomputersleep never
-                  user=ec2-user
-                  su - "${!user}" -c 'brew install buildkite/buildkite/buildkite-agent'
+                  sudo -u ec2-user -i <<'EOF'
+                  export PATH="/opt/homebrew/bin:$PATH"
+                  brew install buildkite/buildkite/buildkite-agent
                   config="$(brew --prefix)"/etc/buildkite-agent/buildkite-agent.cfg
                   sed -i '' "s/xxx/${BuildkiteAgentToken}/g" "${!config}"
                   echo "tags=\"queue=${BuildkiteAgentQueue},buildkite-mac-stack=%v\"" >> "${!config}"
-                  echo "tags-from-ec2=true" >> "${!config}"
-                  su - "${!user}" -c 'brew services start buildkite/buildkite/buildkite-agent'
+                  echo "tags-from-ec2-meta-data=true" >> "${!config}"
+                  brew services start buildkite/buildkite/buildkite-agent
+                  EOF
               - |
                 #!/bin/bash
                 echo "UserData was disabled"


### PR DESCRIPTION
The current AMI for macOS Sonoma does not include Homebrew in $PATH.

Correct config to use `tags-from-ec2-meta-data` instead of `tags-from-ec2`

Adapted from #14